### PR TITLE
Fix the UIPickerView

### DIFF
--- a/PatchKit/Classes/Controllers/PortalViewController.swift
+++ b/PatchKit/Classes/Controllers/PortalViewController.swift
@@ -387,8 +387,8 @@ extension PortalViewController: UICollectionViewDataSource {
                 let data = searchController.isActive ? filteredBugsRequestsData : bugsRequestsData
                 cell.configure(section: .bugsAndRequests, items: data, onTapRow: { feedback in
                     if let feedback = feedback as? OneWayFeedback {
-                        let viewController = BugsRequestsDetailViewController()
-                        viewController.configure(for: feedback)
+                        let viewController = BugsRequestsDetailViewController(feedback: feedback)
+                        // TODO: viewController.configure(for: feedback)
                         self.navigationController?.pushViewController(viewController, animated: true)
                     }
                 })

--- a/PatchKit/Classes/Views/FeedbackView.swift
+++ b/PatchKit/Classes/Views/FeedbackView.swift
@@ -69,7 +69,7 @@ class FeedbackView: UIView {
     }
     
     func setupData() {
-        typeData = ["Hello", "World"]  // TODO: Connect with actual data
+        typeData = ["", "Hello", "World"]  // TODO: Connect with actual data
     }
     
     func setupAddFileButton() {
@@ -213,6 +213,7 @@ class FeedbackView: UIView {
         typeTextField.placeholder = "Choose type"
         typeTextField.font = UIFont.systemFont(ofSize: 14)
         typeTextField.inputView = typePickerView
+        typeTextField.delegate = self
         addSubview(typeTextField)
     }
     
@@ -267,6 +268,10 @@ class FeedbackView: UIView {
         ])
     }
     
+    /**
+     Checks to see whether the user has made a valid selection.
+     Requires the first element in the component to be an invalid choice.
+     */
     func checkStatus() {
         if typePickerView.selectedRow(inComponent: 0) != -1 {
             if messageTextView.textColor != .lightGray || attachedFiles.count > 0 {
@@ -399,25 +404,20 @@ extension FeedbackView: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         // Reload components to remove the checkmark from previous selection
         pickerView.reloadAllComponents()
-        // Add checkmark to the selected row
-        guard let label = pickerView.view(forRow: row, forComponent: component) as? UILabel else { return }
-        let checkMarkImage = UIImage(named: "checkmark", in: PatchKitImages.resourceBundle, compatibleWith: nil)
-        let checkMarkView = UIImageView(frame: CGRect(x: label.frame.width - 40, y: label.frame.height / 2 - 5.5, width: 15, height: 11))
-        checkMarkView.image = checkMarkImage
-        label.addSubview(checkMarkView)
+        
         // Update the typeTextField and recheck whether the message is ready to send
         typeTextField.text = typeData[row]
         checkStatus()
     }
         
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        var label = UILabel()
-        if let v = view as? UILabel {
-            label = v
-        }
-        label.font = UIFont.systemFont(ofSize: 18)
-        label.text = "    \(typeData[row])"
-        return label
+        let pvr = PickerViewRow()
+        pvr.setup(withText: typeData[row], withView: view)
+        return pvr
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        return 32
     }
     
 }
@@ -430,6 +430,17 @@ extension FeedbackView: RemoveFileDelegate {
         attachmentsCollectionView.reloadData()
         attachmentsCollectionView.collectionViewLayout.invalidateLayout()
         checkStatus()
+    }
+    
+}
+
+// MARK: - TextField Delegate
+extension FeedbackView: UITextFieldDelegate {
+    
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if textField == typeTextField {
+            setupTypePickerView()
+        }
     }
     
 }

--- a/PatchKit/Classes/Views/FeedbackView.swift
+++ b/PatchKit/Classes/Views/FeedbackView.swift
@@ -38,7 +38,7 @@ class FeedbackView: UIView {
     private let typePickerView = UIPickerView()
     private let typeSelectionLabel = UILabel()
     
-    private var tf = UITextField(frame: .zero)
+    private var pickerViewtextField = UITextField(frame: .zero)
     
     public var status = Status.incomplete {
         didSet {
@@ -221,9 +221,9 @@ class FeedbackView: UIView {
         typePickerView.layer.addSublayer(border)
         typePickerView.reloadAllComponents()
         
-        tf.inputAccessoryView = toolbar
-        tf.inputView = typePickerView
-        addSubview(tf)
+        pickerViewtextField.inputAccessoryView = toolbar
+        pickerViewtextField.inputView = typePickerView
+        addSubview(pickerViewtextField)
     }
     
     func setupGestureRecognizer() {
@@ -317,22 +317,28 @@ class FeedbackView: UIView {
     @objc func didTapDone() {
         let row = typePickerView.selectedRow(inComponent: 0)
         typePickerView.selectRow(row, inComponent: 0, animated: true)
-        typeSelectionLabel.text = typeData[row].trimmingCharacters(in: .whitespaces).isEmpty ? "Choose type" : typeData[row]
-        typeSelectionLabel.textColor = typeSelectionLabel.text == "Choose type" ? .lightGray : .black
-        tf.resignFirstResponder()
+        typeSelectionLabel.text =
+            typeData[row].trimmingCharacters(in: .whitespaces).isEmpty
+            ? "Choose type"
+            : typeData[row]
+        typeSelectionLabel.textColor =
+            typeSelectionLabel.text == "Choose type"
+            ? .lightGray
+            : .black
+        pickerViewtextField.resignFirstResponder()
     }
     
     @objc func didTapCancel() {
         typeSelectionLabel.text = "Choose type"
         typeSelectionLabel.textColor = .lightGray
-        tf.resignFirstResponder()
+        pickerViewtextField.resignFirstResponder()
     }
     
     @objc func showPickerView(_ sender: UIToolbar) {
         let row = typePickerView.selectedRow(inComponent: 0)
         typeSelectionLabel.text = typeData[row > -1 ? row : 0]
         typeSelectionLabel.textColor = .black
-        tf.becomeFirstResponder()
+        pickerViewtextField.becomeFirstResponder()
     }
     
     required init?(coder: NSCoder) {
@@ -424,9 +430,9 @@ extension FeedbackView: UIPickerViewDelegate {
         pickerView.reloadAllComponents()
 
         // Hide the checkmark for any non-selected rows
-        for r in 0..<typeData.count {
-            if let rowview = pickerView.view(forRow: r, forComponent: component) as? PickerViewRow {
-                rowview.checkMarkImageView.isHidden = r != row
+        for index in 0..<typeData.count {
+            if let rowView = pickerView.view(forRow: index, forComponent: component) as? PickerViewRow {
+                rowView.checkMarkImageView.isHidden = index != row
             }
         }
         

--- a/PatchKit/Classes/Views/PickerViewRow.swift
+++ b/PatchKit/Classes/Views/PickerViewRow.swift
@@ -1,0 +1,61 @@
+//
+//  PickerViewRow.swift
+//  PatchKit
+//
+//  Created by Cameron Russell on 6/23/20.
+//
+
+import UIKit
+
+class PickerViewRow: UIView {
+    
+    public var isSelected = false
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    public func setup(withText text: String, withView view: UIView?) {
+        var label = UILabel()
+        if let v = view as? UILabel {
+            label = v
+        }
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 18)
+        label.text = text
+        
+        addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 25),
+            label.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
+        
+        if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let checkMarkImageView = UIImageView()
+            checkMarkImageView.translatesAutoresizingMaskIntoConstraints = false
+            checkMarkImageView.image = UIImage(named: "checkmark", in: PatchKitImages.resourceBundle, compatibleWith: nil)
+            
+            addSubview(checkMarkImageView)
+            NSLayoutConstraint.activate([
+                checkMarkImageView.trailingAnchor.constraint(equalTo: self.leadingAnchor, constant: UIScreen.main.bounds.width - 25),
+                checkMarkImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                checkMarkImageView.widthAnchor.constraint(equalToConstant: 15),
+                checkMarkImageView.heightAnchor.constraint(equalToConstant: 11)
+            ])
+        }
+        
+        NSLayoutConstraint.activate([
+            self.heightAnchor.constraint(equalToConstant: 32)
+        ])
+    }
+    
+    public func hideCheckMark() {
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}

--- a/PatchKit/Classes/Views/PickerViewRow.swift
+++ b/PatchKit/Classes/Views/PickerViewRow.swift
@@ -9,7 +9,8 @@ import UIKit
 
 class PickerViewRow: UIView {
     
-    public var isSelected = false
+    public let checkMarkImageView = UIImageView()
+    private var label = UILabel()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -17,7 +18,6 @@ class PickerViewRow: UIView {
     }
     
     public func setup(withText text: String, withView view: UIView?) {
-        var label = UILabel()
         if let v = view as? UILabel {
             label = v
         }
@@ -32,7 +32,6 @@ class PickerViewRow: UIView {
         ])
         
         if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let checkMarkImageView = UIImageView()
             checkMarkImageView.translatesAutoresizingMaskIntoConstraints = false
             checkMarkImageView.image = UIImage(named: "checkmark", in: PatchKitImages.resourceBundle, compatibleWith: nil)
             
@@ -48,10 +47,6 @@ class PickerViewRow: UIView {
         NSLayoutConstraint.activate([
             self.heightAnchor.constraint(equalToConstant: 32)
         ])
-    }
-    
-    public func hideCheckMark() {
-        
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Overview

The UIPickerView was broken before. It is no longer broken.


## Changes Made

The user can no longer make custom edit the feedback type. Before, if the two options were "Hello" and "World," they could have typed in a random string and it would be valid.

When **reopening** the UIPickerView, the checkmark disappeared for the previously selected row. This no longer occurs.

I abstracted out the view for each row of the UIPickerView. This may have been unnecessary, but it makes it a little easier to maintain. 


## Test Coverage

All testing was done manually. 


## Next Steps

I need to move all the logic from the Feedback view into a view controller.
